### PR TITLE
Add dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,39 @@
-<<<<<<< HEAD
 # Pig Detector - OpenCV + PyTorch 项目
 
-本项目用于使用 Python + OpenCV + PyTorch 训练“猪识别模型”，导出为 ONNX 格式，供 Java 的 OpenCV (4.5.5) 使用。
+该项目用于使用 Python + OpenCV + PyTorch 训练"猪识别模型"，并可导出 ONNX 模型以供 Java 的 OpenCV (4.5.5) 调用。当前仓库仅提供代码框架，未包含已训练的权重。
 
-## 📁 项目目录结构说明
+## 📁 项目目录结构
 
 ```
 pig-detector-opencv/
-├── data/                   
-│   ├── train/              
-│   └── val/                
+├── data/           # 训练与验证数据集
+│   ├── train/
+│   └── val/
 │
-├── models/                 
-│   ├── best_model.pth      
-│   └── model.onnx          
-│
-├── scripts/                
+├── scripts/        # 训练与推理脚本
 │   ├── train.py
 │   ├── predict.py
 │   └── export_to_onnx.py
 │
-├── utils/                  
-│   ├── model.py            
-│   ├── dataset.py          
-│   └── transforms.py       
+├── utils/          # 数据集与模型工具
+│   ├── model.py
+│   ├── dataset.py
+│   └── transforms.py
 │
-├── config.yaml             
-├── requirements.txt        
-├── .gitignore              
-└── README.md               
+├── config.yaml     # 训练参数示例
+├── requirements.txt
+├── .gitignore
+└── README.md
 ```
 
----
-=======
-# pig-detector-opencv-
-猪只识别
->>>>>>> 7c142ba4909f555f91f7c64328d7bdda175e9f8c
+## 快速开始
+1. 安装依赖：`pip install -r requirements.txt`
+2. 在 `config.yaml` 中配置数据集路径和训练参数。
+3. 运行 `python scripts/train.py` 开始训练，训练完成后会在 `models/` 目录下保存权重。
+4. 如需在 Java 中使用，可执行 `python scripts/export_to_onnx.py` 导出 ONNX 模型。
+
+运行上述脚本时若仅查看 `--help` 信息，可在未安装深度学习依赖的情况下执行。
+真正训练或导出模型则需要提前安装 `torch`、`torchvision` 等依赖，确保环境支持 GPU
+或 CPU 推理。
+
+> **注意**：本仓库仅提供代码框架，未包含已训练的模型。若要获得可用的检测效果，请在本地安装好 `torch`、`torchvision` 等依赖后自行训练。

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 
 ```
 pig-detector-opencv/
-├── data/           # 训练与验证数据集
+├── data/           # 训练与验证数据集 (YOLO 格式)
 │   ├── train/
+│   │   ├── images/  # 图片文件
+│   │   └── labels/  # 同名 .txt，格式: class cx cy w h
 │   └── val/
+│       ├── images/
+│       └── labels/
 │
 ├── scripts/        # 训练与推理脚本
 │   ├── train.py
@@ -31,6 +35,9 @@ pig-detector-opencv/
 2. 在 `config.yaml` 中配置数据集路径和训练参数。
 3. 运行 `python scripts/train.py` 开始训练，训练完成后会在 `models/` 目录下保存权重。
 4. 如需在 Java 中使用，可执行 `python scripts/export_to_onnx.py` 导出 ONNX 模型。
+
+数据集采用 YOLO v5 标注格式，`utils.dataset.YoloDataset` 会在加载时将相对坐标
+转换为像素级的左上角、右下角坐标，以便传入 Faster R-CNN 模型训练。
 
 运行上述脚本时若仅查看 `--help` 信息，可在未安装深度学习依赖的情况下执行。
 真正训练或导出模型则需要提前安装 `torch`、`torchvision` 等依赖，确保环境支持 GPU

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+# 训练参数示例
+train_dir: data/train
+val_dir: data/val
+num_classes: 1             # 仅检测猪
+batch_size: 4
+num_epochs: 10
+learning_rate: 0.001
+model_dir: models

--- a/scripts/export_to_onnx.py
+++ b/scripts/export_to_onnx.py
@@ -1,0 +1,48 @@
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - handled at runtime
+    yaml = None
+torch = None
+
+
+def load_config(path: str):
+    if yaml is None:
+        raise RuntimeError(
+            "pyyaml is not installed. Please install dependencies from requirements.txt"
+        )
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def export(cfg_path: str, weights: str, output: str):
+    global torch
+    if torch is None:
+        import importlib
+        torch = importlib.import_module('torch')
+    from utils.model import create_model
+    cfg = load_config(cfg_path)
+    model = create_model(cfg['num_classes'] + 1)
+    state_dict = torch.load(weights, map_location='cpu')
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    dummy = torch.zeros(1, 3, 640, 640)
+    torch.onnx.export(model, dummy, output, opset_version=11)
+    print(f'ONNX model saved to {output}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='config.yaml')
+    parser.add_argument('--weights', default='models/best_model.pth')
+    parser.add_argument('--output', default='models/model.onnx')
+    args = parser.parse_args()
+    export(args.config, args.weights, args.output)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -1,0 +1,71 @@
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - handled at runtime
+    yaml = None
+
+torch = None
+Image = None
+F = None
+
+
+def load_config(path: str):
+    if yaml is None:
+        raise RuntimeError(
+            "pyyaml is not installed. Please install dependencies from requirements.txt"
+        )
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def load_model(cfg_path: str, weight_path: str):
+    global torch
+    if torch is None:
+        import importlib
+        torch = importlib.import_module('torch')
+    from utils.model import create_model
+    cfg = load_config(cfg_path)
+    model = create_model(cfg['num_classes'] + 1)
+    state_dict = torch.load(weight_path, map_location='cpu')
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model
+
+
+def main(args):
+    global Image, F
+    if Image is None or F is None:
+        from PIL import Image as PILImage
+        import torchvision.transforms.functional as TF
+        Image = PILImage
+        F = TF
+    model = load_model(args.config, args.weights)
+    img = Image.open(args.image).convert('RGB')
+    tensor = F.to_tensor(img)
+    outputs = model([tensor])[0]
+    boxes = outputs['boxes'].detach().numpy()
+    scores = outputs['scores'].detach().numpy()
+
+    for box, score in zip(boxes, scores):
+        if score < 0.5:
+            continue
+        x1, y1, x2, y2 = box
+        length = x2 - x1
+        weight = (y2 - y1) * 0.1  # 仅示例，实际需标定
+        print(f"pig detected at [{x1:.1f}, {y1:.1f}, {x2:.1f}, {y2:.1f}], length={length:.1f}, weight~{weight:.1f}kg")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='config.yaml')
+    parser.add_argument('--weights', default='models/best_model.pth')
+    parser.add_argument('--image', required=True)
+    args = parser.parse_args()
+    main(args)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,79 @@
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - handled at runtime
+    yaml = None
+
+try:
+    import torch
+    from torch.utils.data import DataLoader
+    from torchvision.ops import misc as misc_nn_ops
+except ImportError:  # pragma: no cover - handled at runtime
+    torch = None
+
+
+
+def load_config(path: str):
+    if yaml is None:
+        raise RuntimeError(
+            "pyyaml is not installed. Please install dependencies from requirements.txt"
+        )
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def train(args):
+    if torch is None:
+        raise RuntimeError(
+            "PyTorch is not installed. Please install dependencies from requirements.txt"
+        )
+    from utils.dataset import YoloDataset
+    from utils.model import create_model
+    from utils.transforms import get_train_transforms, get_val_transforms
+    cfg = load_config(args.config)
+
+    train_ds = YoloDataset(cfg['train_dir'], transforms=get_train_transforms())
+    val_ds = YoloDataset(cfg['val_dir'], transforms=get_val_transforms())
+
+    train_loader = DataLoader(train_ds, batch_size=cfg['batch_size'], shuffle=True, collate_fn=lambda x: tuple(zip(*x)))
+    val_loader = DataLoader(val_ds, batch_size=1, shuffle=False, collate_fn=lambda x: tuple(zip(*x)))
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = create_model(cfg['num_classes'] + 1)  # +1 for background
+    model.to(device)
+
+    params = [p for p in model.parameters() if p.requires_grad]
+    optimizer = torch.optim.SGD(params, lr=cfg['learning_rate'], momentum=0.9, weight_decay=0.0005)
+
+    for epoch in range(cfg['num_epochs']):
+        model.train()
+        for images, targets in train_loader:
+            images = list(img.to(device) for img in images)
+            targets = [{k: v.to(device) for k, v in t.items()} for t in targets]
+
+            loss_dict = model(images, targets)
+            losses = sum(loss for loss in loss_dict.values())
+
+            optimizer.zero_grad()
+            losses.backward()
+            optimizer.step()
+
+        print(f"Epoch {epoch+1} done, loss: {losses.item():.4f}")
+
+    Path(cfg['model_dir']).mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), Path(cfg['model_dir']) / 'best_model.pth')
+    print('Training finished, model saved.')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Train pig detector')
+    parser.add_argument('--config', default='config.yaml', help='Path to config file')
+    args = parser.parse_args()
+    train(args)

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -33,8 +33,16 @@ class YoloDataset(Dataset):
                     continue
                 # YOLO 格式: class cx cy w h (相对值)
                 cx, cy, w, h = map(float, parts[1:])
-                boxes.append([cx, cy, w, h])
-        target = {"boxes": torch.tensor(boxes, dtype=torch.float32), "labels": torch.ones(len(boxes), dtype=torch.int64)}
+                # 转为左上角-右下角绝对坐标
+                x1 = (cx - w / 2) * img.width
+                y1 = (cy - h / 2) * img.height
+                x2 = (cx + w / 2) * img.width
+                y2 = (cy + h / 2) * img.height
+                boxes.append([x1, y1, x2, y2])
+        target = {
+            "boxes": torch.tensor(boxes, dtype=torch.float32),
+            "labels": torch.ones(len(boxes), dtype=torch.int64),
+        }
         if self.transforms:
             img = self.transforms(img)
         return img, target

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+
+
+class YoloDataset(Dataset):
+    """读取YOLO格式标注的数据集"""
+
+    def __init__(self, root: str, transforms=None):
+        self.root = Path(root)
+        self.transforms = transforms
+        self.imgs = sorted((self.root / "images").glob("*.jpg"))
+        self.labels = sorted((self.root / "labels").glob("*.txt"))
+        assert len(self.imgs) == len(self.labels), "Image/label count mismatch"
+
+    def __len__(self) -> int:
+        return len(self.imgs)
+
+    def __getitem__(self, idx: int) -> Tuple[Image.Image, dict]:
+        img_path = self.imgs[idx]
+        label_path = self.labels[idx]
+
+        img = Image.open(img_path).convert("RGB")
+        boxes: List[List[float]] = []
+        with open(label_path, "r") as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) != 5:
+                    continue
+                # YOLO 格式: class cx cy w h (相对值)
+                cx, cy, w, h = map(float, parts[1:])
+                boxes.append([cx, cy, w, h])
+        target = {"boxes": torch.tensor(boxes, dtype=torch.float32), "labels": torch.ones(len(boxes), dtype=torch.int64)}
+        if self.transforms:
+            img = self.transforms(img)
+        return img, target

--- a/utils/model.py
+++ b/utils/model.py
@@ -1,0 +1,9 @@
+import torchvision
+
+
+def create_model(num_classes: int):
+    """构建一个简单的 Faster R-CNN 模型"""
+    model = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights=None)
+    in_features = model.roi_heads.box_predictor.cls_score.in_features
+    model.roi_heads.box_predictor = torchvision.models.detection.faster_rcnn.FastRCNNPredictor(in_features, num_classes)
+    return model

--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -1,0 +1,13 @@
+from torchvision import transforms
+
+
+def get_train_transforms():
+    return transforms.Compose([
+        transforms.ToTensor(),
+    ])
+
+
+def get_val_transforms():
+    return transforms.Compose([
+        transforms.ToTensor(),
+    ])


### PR DESCRIPTION
## Summary
- improve README with help usage note
- update scripts to allow running --help without installed dependencies
- ensure root path added to Python path for scripts

## Testing
- `python3 -m py_compile scripts/train.py scripts/predict.py scripts/export_to_onnx.py utils/dataset.py utils/model.py utils/transforms.py`
- `pytest -q` *(no tests found)*
- `python3 scripts/train.py --help`
- `python3 scripts/predict.py --help`
- `python3 scripts/export_to_onnx.py --help`


------
https://chatgpt.com/codex/tasks/task_e_684f85403914832ebfd822ad7f4c68d1